### PR TITLE
 Properly escape the cmd_line

### DIFF
--- a/mkboot
+++ b/mkboot
@@ -256,10 +256,13 @@ ramdisk=ramdisk
 #print boot.img info
 print_info
 
+esq="'\"'\"'"
+escaped_cmd_line=`echo $cmd_line | sed "s/'/$esq/g"`
+
 #write info to img_info,decompression ramdisk.packed
 printf "kernel=kernel\nramdisk=ramdisk\n${s_name}${dt_name}page_size=$page_size\n\
 kernel_size=$kernel_size\nramdisk_size=$ramdisk_size\n${s_size}${dt_size}base_addr=$base_addr\nkernel_offset=$kernel_offset\n\
-ramdisk_offset=$ramdisk_offset\ntags_offset=$tags_offset\ncmd_line=\"$cmd_line\"\nboard=\"$board\"\n" > img_info
+ramdisk_offset=$ramdisk_offset\ntags_offset=$tags_offset\ncmd_line=\'$escaped_cmd_line\'\nboard=\"$board\"\n" > img_info
 mkdir ramdisk
 cd ramdisk
 


### PR DESCRIPTION
Previously img_info was created using double quotes and that
allows a lot of shell interpretation that can cause problems.
Switch to using ' to avoid most of the shell interpretation
(all that is left is ').  Make sure that works well by escaping
single quotes properly.

For example, the command line:

boo='ya' androidboot.selinux=permissive hi='there'

would be escaped in img_info as

cmd_line='boo='"'"'ya'"'"' androidboot.selinux=permissive hi='"'"'there'"'"''